### PR TITLE
Added function that prepares RGB565 image array to be fed into the ST7789_DrawImage function 

### DIFF
--- a/ST7789/st7789.c
+++ b/ST7789/st7789.c
@@ -399,14 +399,14 @@ void ST7789_DrawCircle(uint16_t x0, uint16_t y0, uint8_t r, uint16_t color)
 /**
  * @brief Prepare image array for ST7789_DrawImage function
  *        by exchanging high and low bytes in a uint16_t
- * @param size -> size of array
- * @param array -> pointer to array
+ * @param size -> size of image array
+ * @param image -> pointer to image array
  * @return none
  */
-void ST7789_PrepareRGB565_Array(int size, uint16_t *array)
+void ST7789_PrepareRGB565_ImageArray(int size, uint16_t *image)
 {
     for (int i=0;i<size;i++)
-        array[i] = array[i]>>8 | array[i] & 0xFF;
+        image[i] = image[i]>>8 | image[i] & 0xFF;
 }
 
 /**

--- a/ST7789/st7789.c
+++ b/ST7789/st7789.c
@@ -406,7 +406,7 @@ void ST7789_DrawCircle(uint16_t x0, uint16_t y0, uint8_t r, uint16_t color)
 void ST7789_PrepareRGB565_ImageArray(int size, uint16_t *image)
 {
     for (int i=0;i<size;i++)
-        image[i] = image[i]>>8 | image[i] & 0xFF;
+        image[i] = image[i]>>8 | (image[i] & 0xFF)<<8;
 }
 
 /**

--- a/ST7789/st7789.c
+++ b/ST7789/st7789.c
@@ -397,6 +397,19 @@ void ST7789_DrawCircle(uint16_t x0, uint16_t y0, uint8_t r, uint16_t color)
 }
 
 /**
+ * @brief Prepare image array for ST7789_DrawImage function
+ *        by exchanging high and low bytes in a uint16_t
+ * @param size -> size of array
+ * @param array -> pointer to array
+ * @return none
+ */
+void ST7789_PrepareRGB565_Array(int size, uint16_t *array)
+{
+    for (int i=0;i<size;i++)
+        array[i] = array[i]>>8 | array[i] & 0xFF;
+}
+
+/**
  * @brief Draw an Image on the screen
  * @param x&y -> start point of the Image
  * @param w&h -> width & height of the Image to Draw

--- a/ST7789/st7789.h
+++ b/ST7789/st7789.h
@@ -239,6 +239,7 @@ void ST7789_DrawPixel_4px(uint16_t x, uint16_t y, uint16_t color);
 void ST7789_DrawLine(uint16_t x1, uint16_t y1, uint16_t x2, uint16_t y2, uint16_t color);
 void ST7789_DrawRectangle(uint16_t x1, uint16_t y1, uint16_t x2, uint16_t y2, uint16_t color);
 void ST7789_DrawCircle(uint16_t x0, uint16_t y0, uint8_t r, uint16_t color);
+void ST7789_PrepareRGB565_Array(int size, uint16_t *image);
 void ST7789_DrawImage(uint16_t x, uint16_t y, uint16_t w, uint16_t h, const uint16_t *data);
 void ST7789_InvertColors(uint8_t invert);
 

--- a/ST7789/st7789.h
+++ b/ST7789/st7789.h
@@ -239,7 +239,7 @@ void ST7789_DrawPixel_4px(uint16_t x, uint16_t y, uint16_t color);
 void ST7789_DrawLine(uint16_t x1, uint16_t y1, uint16_t x2, uint16_t y2, uint16_t color);
 void ST7789_DrawRectangle(uint16_t x1, uint16_t y1, uint16_t x2, uint16_t y2, uint16_t color);
 void ST7789_DrawCircle(uint16_t x0, uint16_t y0, uint8_t r, uint16_t color);
-void ST7789_PrepareRGB565_Array(int size, uint16_t *image);
+void ST7789_PrepareRGB565_ImageArray(int size, uint16_t *image);
 void ST7789_DrawImage(uint16_t x, uint16_t y, uint16_t w, uint16_t h, const uint16_t *data);
 void ST7789_InvertColors(uint8_t invert);
 


### PR DESCRIPTION
ST7789_DrawImage function casts the uint16_t value of the image array into a uint8_t which causes the array to be sent to the ST7789 controller low byte first. This results in wrong output and so the proposed solution is to just exchange these high and low bytes beforehand similar to the ST7789_DrawPixel function, with a different function.

#issue 15