### PR TITLE
Update st7789.c

### DIFF
--- a/ST7789/st7789.c
+++ b/ST7789/st7789.c
@@ -44,7 +44,7 @@ static void ST7789_WriteData(uint8_t *buff, size_t buff_size)
 			if (DMA_MIN_SIZE <= buff_size)
 			{
 				HAL_SPI_Transmit_DMA(&ST7789_SPI_PORT, buff, chunk_size);
-				while (ST7789_SPI_PORT.hdmatx->State != HAL_DMA_STATE_READY)
+				while (ST7789_SPI_PORT.State != HAL_SPI_STATE_READY)
 				{}
 			}
 			else


### PR DESCRIPTION
To determine whether a frame of spi data is transfered, the spi ready flag should be used instead of the dma ready flag.
The driver can run well on STM32H7.